### PR TITLE
fix: handle not implemented exception

### DIFF
--- a/src/AgentClientProtocol/AgentSideConnection.cs
+++ b/src/AgentClientProtocol/AgentSideConnection.cs
@@ -132,7 +132,6 @@ public sealed class AgentSideConnection : IDisposable
         });
     }
 
-
     public void Dispose()
     {
         cts.Cancel();


### PR DESCRIPTION
If the Agent/Client is not implemented (i.e., the method throws a NotImplementedException), the response will be changed to return a JSON-RPC error.