### PR TITLE
Agent-side client API, concurrent dispatch, and serialization/EOF fixes

### DIFF
--- a/sandbox/ConsoleApp1/Program.cs
+++ b/sandbox/ConsoleApp1/Program.cs
@@ -146,7 +146,7 @@ class ExampleClient : IAcpClient
     }
 
     public ValueTask<CreateTerminalResponse> CreateTerminalAsync(CreateTerminalRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public ValueTask<TerminalOutputRequest> TerminalOutputAsync(TerminalOutputRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public ValueTask<TerminalOutputResponse> TerminalOutputAsync(TerminalOutputRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     public ValueTask<ReleaseTerminalResponse> ReleaseTerminalAsync(ReleaseTerminalRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     public ValueTask<WaitForTerminalExitResponse> WaitForTerminalExitAsync(WaitForTerminalExitRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     public ValueTask<KillTerminalCommandResponse> KillTerminalCommandAsync(KillTerminalCommandRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();

--- a/src/AgentClientProtocol/AcpJsonSerializerContext.cs
+++ b/src/AgentClientProtocol/AcpJsonSerializerContext.cs
@@ -2,7 +2,10 @@ using System.Text.Json.Serialization;
 
 namespace AgentClientProtocol;
 
-[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]
+// WhenWritingNull, not WhenWritingDefault: the latter also drops non-nullable value types at
+// their default — e.g. StopReason.EndTurn (0) serialized PromptResponse as {}, omitting the
+// spec-required stopReason field (likewise ToolCallStatus.Pending / ToolKind.Read).
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(RequestId))]
 [JsonSerializable(typeof(JsonRpcMessage))]
 [JsonSerializable(typeof(JsonRpcRequest))]

--- a/src/AgentClientProtocol/AgentSideConnection.cs
+++ b/src/AgentClientProtocol/AgentSideConnection.cs
@@ -2,13 +2,20 @@ using System.Text.Json;
 
 namespace AgentClientProtocol;
 
-public sealed class AgentSideConnection : IDisposable
+public sealed class AgentSideConnection : IDisposable, IAcpClient
 {
     readonly CancellationTokenSource cts = new();
     readonly JsonRpcEndpoint endpoint;
 
     public AgentSideConnection(IAcpAgent agent, TextReader reader, TextWriter writer)
+        : this(_ => agent, reader, writer)
     {
+    }
+
+    public AgentSideConnection(Func<IAcpClient, IAcpAgent> toAgent, TextReader reader, TextWriter writer)
+    {
+        var agent = toAgent(this);
+
         endpoint = new(
             _ => new(reader.ReadLine()),
             (s, _) =>
@@ -149,6 +156,108 @@ public sealed class AgentSideConnection : IDisposable
         {
             await agent.ExtNotificationAsync(notification.Method, notification.Params ?? default, ct);
         });
+    }
+
+    async ValueTask<TResponse> RequestAsync<TRequest, TResponse>(string method, TRequest request, CancellationToken cancellationToken)
+    {
+        var response = await endpoint.SendRequestAsync(new JsonRpcRequest
+        {
+            Method = method,
+            Id = default,
+            Params = JsonSerializer.SerializeToElement(request, AcpJsonSerializerContext.Default.Options.GetTypeInfo<TRequest>())
+        }, cancellationToken);
+
+        if (response.Error != null)
+        {
+            throw new AcpException($"{response.Error!.Message}", response.Error.Data, response.Error.Code);
+        }
+
+        if (response.Result == null)
+        {
+            return default!;
+        }
+
+        return JsonSerializer.Deserialize(response.Result.Value, AcpJsonSerializerContext.Default.Options.GetTypeInfo<TResponse>())!;
+    }
+
+    async ValueTask NotificationAsync<TNotification>(string method, TNotification notification, CancellationToken cancellationToken)
+    {
+        await endpoint.SendMessageAsync(new JsonRpcNotification
+        {
+            Method = method,
+            Params = JsonSerializer.SerializeToElement(notification, AcpJsonSerializerContext.Default.Options.GetTypeInfo<TNotification>())
+        }, cancellationToken);
+    }
+
+    public ValueTask SessionNotificationAsync(SessionNotification notification, CancellationToken cancellationToken = default)
+    {
+        return NotificationAsync(ClientMethods.SessionUpdate, notification, cancellationToken);
+    }
+
+    public ValueTask<RequestPermissionResponse> RequestPermissionAsync(RequestPermissionRequest request, CancellationToken cancellationToken = default)
+    {
+        return RequestAsync<RequestPermissionRequest, RequestPermissionResponse>(ClientMethods.SessionRequestPermission, request, cancellationToken);
+    }
+
+    public ValueTask<ReadTextFileResponse> ReadTextFileAsync(ReadTextFileRequest request, CancellationToken cancellationToken = default)
+    {
+        return RequestAsync<ReadTextFileRequest, ReadTextFileResponse>(ClientMethods.FsReadTextFile, request, cancellationToken);
+    }
+
+    public ValueTask<WriteTextFileResponse> WriteTextFileAsync(WriteTextFileRequest request, CancellationToken cancellationToken = default)
+    {
+        return RequestAsync<WriteTextFileRequest, WriteTextFileResponse>(ClientMethods.FsWriteTextFile, request, cancellationToken);
+    }
+
+    public ValueTask<CreateTerminalResponse> CreateTerminalAsync(CreateTerminalRequest request, CancellationToken cancellationToken = default)
+    {
+        return RequestAsync<CreateTerminalRequest, CreateTerminalResponse>(ClientMethods.TerminalCreate, request, cancellationToken);
+    }
+
+    public ValueTask<TerminalOutputResponse> TerminalOutputAsync(TerminalOutputRequest request, CancellationToken cancellationToken = default)
+    {
+        return RequestAsync<TerminalOutputRequest, TerminalOutputResponse>(ClientMethods.TerminalOutput, request, cancellationToken);
+    }
+
+    public ValueTask<ReleaseTerminalResponse> ReleaseTerminalAsync(ReleaseTerminalRequest request, CancellationToken cancellationToken = default)
+    {
+        return RequestAsync<ReleaseTerminalRequest, ReleaseTerminalResponse>(ClientMethods.TerminalRelease, request, cancellationToken);
+    }
+
+    public ValueTask<WaitForTerminalExitResponse> WaitForTerminalExitAsync(WaitForTerminalExitRequest request, CancellationToken cancellationToken = default)
+    {
+        return RequestAsync<WaitForTerminalExitRequest, WaitForTerminalExitResponse>(ClientMethods.TerminalWaitForExit, request, cancellationToken);
+    }
+
+    public ValueTask<KillTerminalCommandResponse> KillTerminalCommandAsync(KillTerminalCommandRequest request, CancellationToken cancellationToken = default)
+    {
+        return RequestAsync<KillTerminalCommandRequest, KillTerminalCommandResponse>(ClientMethods.TerminalKill, request, cancellationToken);
+    }
+
+    public async ValueTask<JsonElement> ExtMethodAsync(string method, JsonElement request, CancellationToken cancellationToken = default)
+    {
+        var response = await endpoint.SendRequestAsync(new JsonRpcRequest
+        {
+            Method = method,
+            Id = default,
+            Params = request,
+        }, cancellationToken);
+
+        if (response.Result == null)
+        {
+            throw new AcpException($"{response.Error!.Message}", response.Error.Data, response.Error.Code);
+        }
+
+        return response.Result.Value;
+    }
+
+    public ValueTask ExtNotificationAsync(string method, JsonElement notification, CancellationToken cancellationToken = default)
+    {
+        return endpoint.SendMessageAsync(new JsonRpcNotification
+        {
+            Method = method,
+            Params = notification
+        }, cancellationToken);
     }
 
     public void Dispose()

--- a/src/AgentClientProtocol/AgentSideConnection.cs
+++ b/src/AgentClientProtocol/AgentSideConnection.cs
@@ -266,8 +266,8 @@ public sealed class AgentSideConnection : IDisposable, IAcpClient
         cts.Dispose();
     }
 
-    public void Open()
+    public Task Open()
     {
-        Task.Run(async () => await endpoint.ReadMessagesAsync(cts.Token));
+        return Task.Run(async () => await endpoint.ReadMessagesAsync(cts.Token));
     }
 }

--- a/src/AgentClientProtocol/ClientSideConnection.cs
+++ b/src/AgentClientProtocol/ClientSideConnection.cs
@@ -109,7 +109,7 @@ public sealed class ClientSideConnection : IDisposable, IAcpAgent
             return new JsonRpcResponse
             {
                 Id = request.Id,
-                Result = JsonSerializer.SerializeToElement(response, AcpJsonSerializerContext.Default.Options.GetTypeInfo<TerminalOutputRequest>())
+                Result = JsonSerializer.SerializeToElement(response, AcpJsonSerializerContext.Default.Options.GetTypeInfo<TerminalOutputResponse>())
             };
         });
 

--- a/src/AgentClientProtocol/ClientSideConnection.cs
+++ b/src/AgentClientProtocol/ClientSideConnection.cs
@@ -276,8 +276,8 @@ public sealed class ClientSideConnection : IDisposable, IAcpAgent
         cts.Dispose();
     }
 
-    public void Open()
+    public Task Open()
     {
-        Task.Run(async () => await endpoint.ReadMessagesAsync(cts.Token));
+        return Task.Run(async () => await endpoint.ReadMessagesAsync(cts.Token));
     }
 }

--- a/src/AgentClientProtocol/IAcpClient.cs
+++ b/src/AgentClientProtocol/IAcpClient.cs
@@ -9,7 +9,7 @@ public interface IAcpClient
     ValueTask<WriteTextFileResponse> WriteTextFileAsync(WriteTextFileRequest request, CancellationToken cancellationToken = default);
     ValueTask<ReadTextFileResponse> ReadTextFileAsync(ReadTextFileRequest request, CancellationToken cancellationToken = default);
     ValueTask<CreateTerminalResponse> CreateTerminalAsync(CreateTerminalRequest request, CancellationToken cancellationToken = default);
-    ValueTask<TerminalOutputRequest> TerminalOutputAsync(TerminalOutputRequest request, CancellationToken cancellationToken = default);
+    ValueTask<TerminalOutputResponse> TerminalOutputAsync(TerminalOutputRequest request, CancellationToken cancellationToken = default);
     ValueTask<ReleaseTerminalResponse> ReleaseTerminalAsync(ReleaseTerminalRequest request, CancellationToken cancellationToken = default);
     ValueTask<WaitForTerminalExitResponse> WaitForTerminalExitAsync(WaitForTerminalExitRequest request, CancellationToken cancellationToken = default);
     ValueTask<KillTerminalCommandResponse> KillTerminalCommandAsync(KillTerminalCommandRequest request, CancellationToken cancellationToken = default);

--- a/src/AgentClientProtocol/JsonRpc/JsonRpcEndpoint.cs
+++ b/src/AgentClientProtocol/JsonRpc/JsonRpcEndpoint.cs
@@ -48,6 +48,7 @@ internal sealed class JsonRpcEndpoint(Func<CancellationToken, ValueTask<string?>
             try
             {
                 var line = await readFunc(cancellationToken).ConfigureAwait(false);
+                if (line is null) return; // EOF — the peer closed the stream
                 if (string.IsNullOrWhiteSpace(line)) continue;
 
                 var trimmedLineSpan = line.AsSpan().Trim();

--- a/src/AgentClientProtocol/JsonRpc/JsonRpcEndpoint.cs
+++ b/src/AgentClientProtocol/JsonRpc/JsonRpcEndpoint.cs
@@ -15,6 +15,7 @@ internal enum JsonRpcErrorCode
 internal sealed class JsonRpcEndpoint(Func<CancellationToken, ValueTask<string?>> readFunc, Func<string, CancellationToken, ValueTask> writeFunc, Func<string, CancellationToken, ValueTask> errorWriteFunc)
 {
     readonly ConcurrentDictionary<RequestId, TaskCompletionSource<JsonRpcResponse>> pendingRequests = new();
+    readonly SemaphoreSlim writeLock = new(1, 1);
     readonly ConcurrentDictionary<string, Func<JsonRpcRequest, CancellationToken, ValueTask<JsonRpcResponse>>> requestHandlers = new();
     readonly ConcurrentDictionary<string, Func<JsonRpcNotification, CancellationToken, ValueTask>> notificationHandlers = new();
     Func<JsonRpcRequest, CancellationToken, ValueTask<JsonRpcResponse>>? defaultRequestHandler;
@@ -59,56 +60,12 @@ internal sealed class JsonRpcEndpoint(Func<CancellationToken, ValueTask<string?>
                 switch (message)
                 {
                     case JsonRpcRequest request:
-                        try
-                        {
-                            if (requestHandlers.TryGetValue(request.Method, out var requestHandler))
-                            {
-                                var response = await requestHandler(request, cancellationToken);
-                                await writeFunc(JsonSerializer.Serialize(response, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
-                            }
-                            else if (defaultRequestHandler != null)
-                            {
-                                var response = await defaultRequestHandler(request, cancellationToken);
-                                await writeFunc(JsonSerializer.Serialize(response, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
-                            }
-                            else
-                            {
-                                await writeFunc(JsonSerializer.Serialize(new JsonRpcResponse
-                                {
-                                    Id = request.Id,
-                                    Error = new()
-                                    {
-                                        Code = (int)JsonRpcErrorCode.MethodNotFound,
-                                        Message = $"Method '{request.Method}' is not available",
-                                    }
-                                }, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
-                            }
-                        }
-                        catch (NotImplementedException)
-                        {
-                            await writeFunc(JsonSerializer.Serialize(new JsonRpcResponse
-                            {
-                                Id = request.Id,
-                                Error = new()
-                                {
-                                    Code = (int)JsonRpcErrorCode.MethodNotFound,
-                                    Message = $"Method '{request.Method}' is not available",
-                                }
-                            }, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
-                        }
-                        catch (AcpException acpException)
-                        {
-                            await writeFunc(JsonSerializer.Serialize(new JsonRpcResponse
-                            {
-                                Id = request.Id,
-                                Error = new()
-                                {
-                                    Code = acpException.Code,
-                                    Data = acpException.ErrorData,
-                                    Message = acpException.Message,
-                                }
-                            }, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
-                        }
+                        // Dispatch without awaiting: a long-running handler (e.g. an agent's
+                        // session/prompt) must not block the read loop, or an in-flight
+                        // session/cancel could never be processed and a handler that calls
+                        // back to the peer (e.g. session/request_permission) would deadlock
+                        // waiting for a response this loop can no longer read.
+                        _ = Task.Run(() => HandleRequestAsync(request, cancellationToken).AsTask(), cancellationToken);
                         break;
                     case JsonRpcResponse response:
                         {
@@ -119,14 +76,7 @@ internal sealed class JsonRpcEndpoint(Func<CancellationToken, ValueTask<string?>
                         }
                         break;
                     case JsonRpcNotification notification:
-                        if (notificationHandlers.TryGetValue(notification.Method, out var notificationHandler))
-                        {
-                            await notificationHandler(notification, cancellationToken);
-                        }
-                        else if (defaultNotificationHandler != null)
-                        {
-                            await defaultNotificationHandler(notification, cancellationToken);
-                        }
+                        _ = Task.Run(() => HandleNotificationAsync(notification, cancellationToken).AsTask(), cancellationToken);
                         break;
                     default:
                         throw new AcpException($"Invalid response type: {message?.GetType().Name}", null, (int)JsonRpcErrorCode.InternalError);
@@ -143,6 +93,110 @@ internal sealed class JsonRpcEndpoint(Func<CancellationToken, ValueTask<string?>
         }
     }
 
+    async ValueTask HandleRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (requestHandlers.TryGetValue(request.Method, out var requestHandler))
+            {
+                var response = await requestHandler(request, cancellationToken);
+                await WriteAsync(JsonSerializer.Serialize(response, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
+            }
+            else if (defaultRequestHandler != null)
+            {
+                var response = await defaultRequestHandler(request, cancellationToken);
+                await WriteAsync(JsonSerializer.Serialize(response, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
+            }
+            else
+            {
+                await WriteAsync(JsonSerializer.Serialize(new JsonRpcResponse
+                {
+                    Id = request.Id,
+                    Error = new()
+                    {
+                        Code = (int)JsonRpcErrorCode.MethodNotFound,
+                        Message = $"Method '{request.Method}' is not available",
+                    }
+                }, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
+            }
+        }
+        catch (NotImplementedException)
+        {
+            await WriteAsync(JsonSerializer.Serialize(new JsonRpcResponse
+            {
+                Id = request.Id,
+                Error = new()
+                {
+                    Code = (int)JsonRpcErrorCode.MethodNotFound,
+                    Message = $"Method '{request.Method}' is not available",
+                }
+            }, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
+        }
+        catch (AcpException acpException)
+        {
+            await WriteAsync(JsonSerializer.Serialize(new JsonRpcResponse
+            {
+                Id = request.Id,
+                Error = new()
+                {
+                    Code = acpException.Code,
+                    Data = acpException.ErrorData,
+                    Message = acpException.Message,
+                }
+            }, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            await WriteAsync(JsonSerializer.Serialize(new JsonRpcResponse
+            {
+                Id = request.Id,
+                Error = new()
+                {
+                    Code = (int)JsonRpcErrorCode.InternalError,
+                    Message = ex.Message,
+                }
+            }, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>()), cancellationToken);
+        }
+    }
+
+    async ValueTask HandleNotificationAsync(JsonRpcNotification notification, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (notificationHandlers.TryGetValue(notification.Method, out var notificationHandler))
+            {
+                await notificationHandler(notification, cancellationToken);
+            }
+            else if (defaultNotificationHandler != null)
+            {
+                await defaultNotificationHandler(notification, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            await errorWriteFunc(ex.ToString(), cancellationToken);
+        }
+    }
+
+    async ValueTask WriteAsync(string json, CancellationToken cancellationToken)
+    {
+        await writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await writeFunc(json, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            writeLock.Release();
+        }
+    }
+
     public async ValueTask SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
     {
         if (message is JsonRpcRequest request && !request.Id.IsValid)
@@ -151,7 +205,7 @@ internal sealed class JsonRpcEndpoint(Func<CancellationToken, ValueTask<string?>
         }
 
         var json = JsonSerializer.Serialize(message, AcpJsonSerializerContext.Default.Options.GetTypeInfo<JsonRpcMessage>());
-        await writeFunc(json, cancellationToken).ConfigureAwait(false);
+        await WriteAsync(json, cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken = default)
@@ -163,7 +217,7 @@ internal sealed class JsonRpcEndpoint(Func<CancellationToken, ValueTask<string?>
         var tcs = new TaskCompletionSource<JsonRpcResponse>();
         pendingRequests.TryAdd(request.Id, tcs);
 
-        await writeFunc(json, cancellationToken).ConfigureAwait(false);
+        await WriteAsync(json, cancellationToken).ConfigureAwait(false);
 
         return await tcs.Task;
     }


### PR DESCRIPTION
Hi! We're using acp-csharp to add ACP support to a .NET agent and hit a few gaps building the **agent** side. This PR carries five commits, each independently revertable:

1. **fix: terminal/output response uses TerminalOutputResponse** — `IAcpClient.TerminalOutputAsync` returned `TerminalOutputRequest` and the client-side handler serialized the result with the request type info, so responses never matched the spec schema.

2. **feat: expose client-bound API on AgentSideConnection** — `AgentSideConnection` could receive agent methods but gave the agent no way to send `session/update` notifications or call client-bound methods (`session/request_permission`, `fs/*`, `terminal/*`), which the prompt-turn streaming model depends on. It now implements `IAcpClient`, mirroring how `ClientSideConnection` implements `IAcpAgent`, and gains a `Func<IAcpClient, IAcpAgent>` constructor overload so the agent can hold the connection it replies on. The existing constructor is kept for backward compatibility.

3. **fix: stop the read loop at EOF and let callers await it** — `reader.ReadLine()` returning `null` (peer closed the stream) was treated like a blank line, so the loop spun forever at 100% of a core. `Open()` now returns the read-loop `Task` so a host process can await shutdown.

4. **fix: dispatch incoming requests/notifications off the read loop** — handlers were awaited inline in `ReadMessagesAsync`, so a long-running `session/prompt` blocked the loop: `session/cancel` could never be handled mid-prompt, and an agent calling back to the client (`session/request_permission`) deadlocked waiting for a response the blocked loop cannot read. Requests/notifications now run on the thread pool with outbound writes serialized behind a lock; unhandled handler exceptions surface as JSON-RPC internal errors instead of killing the loop.

5. **fix: do not omit required value-type fields when serializing** — `DefaultIgnoreCondition.WhenWritingDefault` dropped non-nullable value types at their default: `PromptResponse` serialized as `{}` whenever `StopReason` was `EndTurn` (enum 0), omitting the spec-required `stopReason`; `ToolCallStatus.Pending` / `ToolKind.Read` vanished the same way. `WhenWritingNull` keeps optional-field omission (`_meta` etc.) without eating required enums.

Verified end-to-end against a real agent implementation over stdio: initialize → session/new → session/set_model → session/prompt with streamed `session/update` chunks, `stopReason` present, clean exit at EOF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)